### PR TITLE
Fix RuboCop offenses and update RuboCop infrastructure

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,10 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 2.5
 
+# Make BeginEndAlignment behavior match EndAlignment
+Layout/BeginEndAlignment:
+  EnforcedStyleAlignWith: begin
+
 # Be lenient with line length
 Layout/LineLength:
   Max: 92

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ require:
 AllCops:
   Exclude:
     - 'tmp/**/*'
+    - 'vendor/bundle/**/*'
   NewCops: enable
   TargetRubyVersion: 2.5
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,16 @@ before_script:
 cache:
   bundler: true
 
-rvm:
-  - 2.5
-  - 2.6
-  - 2.7
-  - ruby-head
-
-matrix:
+jobs:
+  include:
+    - rvm: 2.5
+    - rvm: 2.6
+    - rvm: 2.7
+    - rvm: ruby-head
+    - rvm: 2.7.1
+      name: "RuboCop"
+      before_install: []
+      script: bundle exec rubocop
   allow_failures:
     - rvm: ruby-head
 

--- a/keep_up.gemspec
+++ b/keep_up.gemspec
@@ -32,5 +32,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "cucumber", "~> 5.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rubocop", "~> 0.92.0"
+  spec.add_development_dependency "rubocop-performance", "~> 1.8.0"
+  spec.add_development_dependency "rubocop-rspec", "~> 1.43.2"
   spec.add_development_dependency "simplecov", "~> 0.19.0"
 end

--- a/lib/keep_up/version_control.rb
+++ b/lib/keep_up/version_control.rb
@@ -8,7 +8,8 @@ module KeepUp
     end
 
     def commit_changes(dependency)
-      @runner.run "git commit -am 'Update #{dependency.name} to version #{dependency.version}'"
+      message = "Update #{dependency.name} to version #{dependency.version}"
+      @runner.run "git commit -am '#{message}'"
     end
 
     def revert_changes


### PR DESCRIPTION
Fix RuboCop offenses:
- Configure BeginEndAlignment cop to match EndAlignment
- Break up long line

Update RuboCop infrastructure:
- Add rubocop gems as development dependencies
- Run RuboCop on Travis as a separate job