### PR TITLE
Use new way to set bundle installation path in cukes

### DIFF
--- a/features/step_definitions/basic_step.rb
+++ b/features/step_definitions/basic_step.rb
@@ -61,7 +61,8 @@ Given "a gem named {string} at version {string} depending on {string} at version
 end
 
 Given "the initial bundle install committed" do
-  run_command_and_stop "bundle install --quiet --path=vendor"
+  run_command_and_stop "bundle config set path 'vendor'"
+  run_command_and_stop "bundle install --quiet"
   write_file ".gitignore", "libs/\nvendor/"
   run_command_and_stop "git init -q"
   run_command_and_stop "git config user.name 'Foo Bar'"

--- a/features/step_definitions/basic_step.rb
+++ b/features/step_definitions/basic_step.rb
@@ -61,8 +61,12 @@ Given "a gem named {string} at version {string} depending on {string} at version
 end
 
 Given "the initial bundle install committed" do
-  run_command_and_stop "bundle config set path 'vendor'"
-  run_command_and_stop "bundle install --quiet"
+  if Bundler::VERSION < "2.0"
+    run_command_and_stop "bundle install --quiet --path 'vendor'"
+  else
+    run_command_and_stop "bundle config set path 'vendor'"
+    run_command_and_stop "bundle install --quiet"
+  end
   write_file ".gitignore", "libs/\nvendor/"
   run_command_and_stop "git init -q"
   run_command_and_stop "git config user.name 'Foo Bar'"


### PR DESCRIPTION
The --path option for bundle is deprecated. The resulting error message leads to build failures on Ruby 3.0.0 preview1. This change updates the cuke step definition to use the suggested replacement instead.