### PR TITLE
Loosen RuboCop dependencies

### DIFF
--- a/keep_up.gemspec
+++ b/keep_up.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop", "~> 1.25.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.13.0"
-  spec.add_development_dependency "rubocop-rspec", "~> 2.7.0"
+  spec.add_development_dependency "rubocop", "~> 1.25"
+  spec.add_development_dependency "rubocop-performance", "~> 1.13"
+  spec.add_development_dependency "rubocop-rspec", "~> 2.7"
   spec.add_development_dependency "simplecov", "~> 0.21.0"
 end


### PR DESCRIPTION
This will decrease churn on the gemspec file. Updating the code for new offenses can be scheduled when it becomes necessary to make the build pass for new pull requests.
