### PR TITLE
Update and configure RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,10 @@ AllCops:
 Layout/BeginEndAlignment:
   EnforcedStyleAlignWith: begin
 
+# Spaces in strings with line continuations go at the beginning of the line.
+Layout/LineContinuationLeadingSpace:
+  EnforcedStyle: leading
+
 # Be lenient with line length
 Layout/LineLength:
   Max: 92
@@ -85,7 +89,7 @@ Style/RedundantReturn:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
-# Consistency
+# Make quoting outside and inside interpolation consistent
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ inherit_mode:
     - Exclude
 
 require:
+  - rubocop-packaging
   - rubocop-performance
   - rubocop-rspec
 

--- a/bin/keep_up
+++ b/bin/keep_up
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "optparse"
-require_relative "../lib/keep_up"
+require "keep_up"
 
 options = {
   local: false,

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,6 +3,7 @@
 require "rubygems/package"
 
 Before do
+  # Set Aruba environment to match unbundled environment
   empty_env = with_environment { ::Bundler.with_unbundled_env { ENV.to_h } }
   aruba_env = aruba.environment.to_h
   (aruba_env.keys - empty_env.keys).each do |key|
@@ -11,4 +12,8 @@ Before do
   empty_env.each do |k, v|
     set_environment_variable k, v
   end
+
+  # Set RUBYLIB so Ruby can find project's lib/ without Bundler
+  project_lib = File.expand_path("../../lib", __dir__)
+  set_environment_variable("RUBYLIB", project_lib)
 end

--- a/keep_up.gemspec
+++ b/keep_up.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop", "~> 1.25"
+  spec.add_development_dependency "rubocop", "~> 1.32"
   spec.add_development_dependency "rubocop-performance", "~> 1.13"
   spec.add_development_dependency "rubocop-rspec", "~> 2.7"
   spec.add_development_dependency "simplecov", "~> 0.21.0"

--- a/keep_up.gemspec
+++ b/keep_up.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "~> 1.32"
+  spec.add_development_dependency "rubocop-packaging", "~> 0.5.1"
   spec.add_development_dependency "rubocop-performance", "~> 1.13"
   spec.add_development_dependency "rubocop-rspec", "~> 2.7"
   spec.add_development_dependency "simplecov", "~> 0.21.0"


### PR DESCRIPTION
- Bump RuboCop version to support LineContinuationLeadingSpace config
- Configure LineContinuationLeadingSpace cop
