### PR TITLE
Replace soft-deprecated runtime dependency specification

### DIFF
--- a/keep_up.gemspec
+++ b/keep_up.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "bundler", [">= 1.15", "< 3.0"]
+  spec.add_dependency "bundler", [">= 1.15", "< 3.0"]
 
   spec.add_development_dependency "aruba", "~> 2.0"
   spec.add_development_dependency "cucumber", "~> 9.0"


### PR DESCRIPTION
Using add_runtime_dependency is soft-deprecated and now flagged by RuboCop.
