### PR TITLE
Allow passing test-command to run after each gem update

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ to find any updates that cause problems and remove or fix them.
   option can be passed multiple times.
 * You can pass `--local` to make KeepUp not try to fetch remote gem version
   information.
+* You can pass `--test-command <COMMAND>` to make KeepUp run the given command
+  to test each update before commiting.
 
 ## Planned Features
 

--- a/bin/keep_up
+++ b/bin/keep_up
@@ -6,7 +6,7 @@ require "keep_up"
 
 options = {
   local: false,
-  test_command: "bundle exec rake",
+  test_command: nil,
   skip: []
 }
 

--- a/lib/keep_up/runner.rb
+++ b/lib/keep_up/runner.rb
@@ -12,6 +12,11 @@ module KeepUp
       stdout
     end
 
+    def run_and_return_status(command)
+      _stdout, status = run2 command
+      status
+    end
+
     def run2(command)
       Open3.capture2 command
     end

--- a/lib/keep_up/version.rb
+++ b/lib/keep_up/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module KeepUp
-  VERSION = "0.11.0"
+  VERSION = "0.12.0"
 end


### PR DESCRIPTION
I came to `keep_up` after my already heavily patched [bundler-auto-update](https://rubygems.org/gems/bundler-auto-update)  gem had more and more problems.

The only thing I was missing is the ability to run `rails test` (or similar) to verify each gem update. 

This PR contains a hacky version of supporting this (and using the cli params you had already provided). I did not get to writing tests and I suppose you'd like a cleaner version but maybe this is useful to others or as a starting point :)