### PR TITLE
Test stdout specifically in Cucumber scenarios, ignoring stderr

### DIFF
--- a/features/basic.feature
+++ b/features/basic.feature
@@ -13,7 +13,7 @@ Feature: Update bundle
 
   Scenario: Nothing to do
     When I run `keep_up`
-    Then the output from "keep_up" should contain exactly:
+    Then the stdout from "keep_up" should contain exactly:
       """
       All done!
       """
@@ -25,7 +25,7 @@ Feature: Update bundle
   Scenario: Updating a gem with a fixed version
     Given a gem named "foo" at version "1.0.1"
     When I run `keep_up`
-    Then the output should contain:
+    Then the stdout should contain:
       """
       Updating foo
       Updated foo to 1.0.1
@@ -40,7 +40,7 @@ Feature: Update bundle
       foo (1.0.1)
       """
     When I run `git log`
-    Then the output should contain:
+    Then the stdout should contain:
       """
       Update foo to version 1.0.1
       """

--- a/features/bundler_as_a_dependency.feature
+++ b/features/bundler_as_a_dependency.feature
@@ -15,7 +15,7 @@ Feature: Update bundle with bundler as a dependency
   Scenario: Updating foo
     Given a gem named "foo" at version "1.0.1"
     When I run `keep_up`
-    Then the output should contain:
+    Then the stdout should contain:
       """
       Updating foo
       Updated foo to 1.0.1

--- a/features/correct_feedback.feature
+++ b/features/correct_feedback.feature
@@ -13,7 +13,7 @@ Feature: Correct feedback
     And a gem named "bar" at version "1.1.0"
     And a gem named "bar" at version "1.2.0"
     When I run `keep_up`
-    Then the output should contain:
+    Then the stdout should contain:
       """
       Updating bar
       Updated bar to 1.1.0
@@ -25,7 +25,7 @@ Feature: Correct feedback
           bar (1.1.0)
       """
     When I run `git log`
-    Then the output should contain:
+    Then the stdout should contain:
       """
       Update bar to version 1.1.0
       """
@@ -39,7 +39,7 @@ Feature: Correct feedback
     And the initial bundle install committed
     And a gem named "bar" at version "1.2.0"
     When I run `keep_up`
-    Then the output should contain:
+    Then the stdout should contain:
       """
       Updating bar
       Failed updating bar to 1.2.0

--- a/features/failed_bundle_update.feature
+++ b/features/failed_bundle_update.feature
@@ -15,14 +15,14 @@ Feature: Skip failing updates
     And a gem named "bar" at version "1.2.0" depending on "foo" at version "1.2.0"
     And a gem named "foo" at version "1.2.0"
     When I run `keep_up`
-    Then the output should contain:
+    Then the stdout should contain:
       """
       Updating bar
       Failed updating bar to 1.2.0
       Updating foo
       Updated foo to 1.2.0
       """
-    And the output should contain:
+    And the stdout should contain:
       """
       All done!
       """

--- a/features/gemspec_dependencies.feature
+++ b/features/gemspec_dependencies.feature
@@ -17,7 +17,7 @@ Feature: Gemspec dependencies
       """
     Given a gem named "foo" at version "1.0.1"
     When I run `keep_up`
-    Then the output should contain:
+    Then the stdout should contain:
       """
       Updating foo
       Updated foo to 1.0.1

--- a/features/indirect_dependencies.feature
+++ b/features/indirect_dependencies.feature
@@ -13,7 +13,7 @@ Feature: Updating indirect dependencies
     And the initial bundle install committed
     And a gem named "bar" at version "1.0.1"
     When I run `keep_up`
-    Then the output should contain exactly:
+    Then the stdout should contain exactly:
       """
       Updating bar
       Updated bar to 1.0.1

--- a/features/matching_specificity.feature
+++ b/features/matching_specificity.feature
@@ -13,7 +13,7 @@ Feature: Matching specificity correctly
     And the initial bundle install committed
     And a gem named "foo" at version "2.1.1"
     When I run `keep_up`
-    Then the output should contain:
+    Then the stdout should contain:
       """
       Updating foo
       Updated foo to 2.1.1
@@ -24,7 +24,7 @@ Feature: Matching specificity correctly
       foo (2.1.1)
       """
     When I run `git log`
-    Then the output should contain:
+    Then the stdout should contain:
       """
       Update foo to version 2.1
       """
@@ -38,7 +38,7 @@ Feature: Matching specificity correctly
     And the initial bundle install committed
     And a gem named "foo" at version "2.1.1"
     When I run `keep_up`
-    Then the output should contain:
+    Then the stdout should contain:
       """
       Updating foo
       Updated foo to 2.1.1
@@ -52,11 +52,11 @@ Feature: Matching specificity correctly
       foo (2.1.1)
       """
     When I run `git log`
-    Then the output should contain:
+    Then the stdout should contain:
       """
       Update foo to version 2.1
       """
-    And the output should not contain:
+    And the stdout should not contain:
       """
       Update foo to version 2.1.1
       """

--- a/features/sanity_check.feature
+++ b/features/sanity_check.feature
@@ -13,12 +13,12 @@ Feature: Sanity check
     And a gem named "foo" at version "1.0.1"
     When I add a file without checking it in
     And I run `keep_up`
-    Then the output should not contain:
+    Then the stdout should not contain:
       """
       Updating foo
       Updated foo to 1.0.1
       """
-    And the output should contain:
+    And the stderr should contain:
       """
       Commit or stash your work before running 'keep_up'
       """
@@ -37,17 +37,17 @@ Feature: Sanity check
       """
     And I commit the changes without updating the bundle
     And I run `keep_up`
-    Then the output should not contain:
+    Then the stdout should not contain:
       """
       Updating foo
       Updated foo to 1.0.1
       """
-    And the output should contain:
+    And the stderr should contain:
       """
       Make sure your Gemfile.lock is up-to-date before running 'keep_up'
       """
     When I run `git status`
-    Then the output should contain:
+    Then the stdout should contain:
       """
       nothing to commit, working tree clean
       """

--- a/features/skipping_dependencies.feature
+++ b/features/skipping_dependencies.feature
@@ -15,7 +15,7 @@ Feature: Skipping dependencies
     And a gem named "bar" at version "1.2.0"
     And a gem named "foo" at version "1.2.0"
     When I run `keep_up --skip bar`
-    Then the output should contain:
+    Then the stdout should contain:
       """
       Updating foo
       Updated foo to 1.2.0

--- a/features/update_approximate_versions.feature
+++ b/features/update_approximate_versions.feature
@@ -14,7 +14,7 @@ Feature: Update bundle with approximate versions
   Scenario: Updating to a version that matches the current spec
     Given a gem named "foo" at version "1.0.1"
     When I run `keep_up`
-    Then the output should contain:
+    Then the stdout should contain:
       """
       Updating foo
       Updated foo to 1.0.1
@@ -31,7 +31,7 @@ Feature: Update bundle with approximate versions
   Scenario: Updating to a version that exceeds the current spec
     Given a gem named "foo" at version "1.1.2"
     When I run `keep_up`
-    Then the output should contain:
+    Then the stdout should contain:
       """
       Updating foo
       Updated foo to 1.1.2

--- a/features/without_dependency_versions.feature
+++ b/features/without_dependency_versions.feature
@@ -12,7 +12,7 @@ Feature: Update bundle with no depenency versions
     And the initial bundle install committed
     And a gem named "foo" at version "1.0.1"
     When I run `keep_up`
-    Then the output should contain:
+    Then the stdout should contain:
       """
       Updating foo
       Updated foo to 1.0.1


### PR DESCRIPTION
Currently, keep_up does not capture stderr from calls to bundler, so any errors that bundler produces can be examined by the user. This means that extra output from bundler to stderr can cause Cucumber scenarios to start failing if we test the whole output.

Since we are only really interested in testing the output from keep_up itself, and stdout from bundler is processed internally and never output to the user, it is better to test the stdout specifically, except where keep_up outputs to stderr.