### PR TITLE
Drop support for Bundler 1.x

### DIFF
--- a/features/step_definitions/basic_step.rb
+++ b/features/step_definitions/basic_step.rb
@@ -67,12 +67,8 @@ Given(
 end
 
 Given "the initial bundle install committed" do
-  if Bundler::VERSION < "2.0"
-    run_command_and_stop "bundle install --quiet --path 'vendor'"
-  else
-    run_command_and_stop "bundle config set path 'vendor'"
-    run_command_and_stop "bundle install --quiet"
-  end
+  run_command_and_stop "bundle config set path 'vendor'"
+  run_command_and_stop "bundle install --quiet"
   write_file ".gitignore", "libs/\nvendor/"
   run_command_and_stop "git init -q"
   run_command_and_stop "git config user.name 'Foo Bar'"

--- a/keep_up.gemspec
+++ b/keep_up.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "bundler", [">= 1.15", "< 3.0"]
+  spec.add_dependency "bundler", "~> 2.0"
 
   spec.add_development_dependency "aruba", "~> 2.0"
   spec.add_development_dependency "cucumber", "~> 9.0"


### PR DESCRIPTION
Version 2.0.0 of Bundler was introduced in 2019, so assume everyone is on version 2.x by now.