### PR TITLE
Speed up preparation of remote gem specifications in cucumber scenarios

### DIFF
--- a/features/basic.feature
+++ b/features/basic.feature
@@ -3,15 +3,22 @@ Feature: Update bundle
   In order to avoid tedious work
   I want to automatically update dependencies
 
-  Background: A project with fixed dependency versions
-    Given a Gemfile specifying:
+  Scenario: Nothing to do
+    Given the following remote gems:
+      | name | version |
+      | foo  | 1.0.0   |
+    And a Gemfile specifying:
       """
       gem 'foo', '1.0.0'
       """
-    And a gem named "foo" at version "1.0.0"
-    And the initial bundle install committed
+    And a Gemfile.lock specifying:
+      """
+      GEM
+        specs:
+          foo (1.0.0)
 
-  Scenario: Nothing to do
+      """
+    And the initial bundle install committed
     When I run `keep_up`
     Then the stdout from "keep_up" should contain exactly:
       """
@@ -23,7 +30,22 @@ Feature: Update bundle
       """
 
   Scenario: Updating a gem with a fixed version
-    Given a gem named "foo" at version "1.0.1"
+    Given the following remote gems:
+      | name | version |
+      | foo  | 1.0.0   |
+      | foo  | 1.0.1   |
+    And a Gemfile specifying:
+      """
+      gem 'foo', '1.0.0'
+      """
+    And a Gemfile.lock specifying:
+      """
+      GEM
+        specs:
+          foo (1.0.0)
+
+      """
+    And the initial bundle install committed
     When I run `keep_up`
     Then the stdout should contain:
       """

--- a/features/bundler_as_a_dependency.feature
+++ b/features/bundler_as_a_dependency.feature
@@ -4,16 +4,25 @@ Feature: Update bundle with bundler as a dependency
   I want keep_up to handle bundler as a dependency
 
   Background: A project with bundler as a dependency
-    Given a Gemfile specifying:
+    Given the following remote gems:
+      | name | version |
+      | foo  | 1.0.0   |
+      | foo  | 1.0.1   |
+    And a Gemfile specifying:
       """
       gem 'foo', '1.0.0'
       gem 'bundler'
       """
-    And a gem named "foo" at version "1.0.0"
+    And a Gemfile.lock specifying:
+      """
+      GEM
+        specs:
+          foo (1.0.0)
+
+      """
     And the initial bundle install committed
 
   Scenario: Updating foo
-    Given a gem named "foo" at version "1.0.1"
     When I run `keep_up`
     Then the stdout should contain:
       """
@@ -25,4 +34,3 @@ Feature: Update bundle with bundler as a dependency
       gem 'foo', '1.0.1'
       gem 'bundler'
       """
-

--- a/features/correct_feedback.feature
+++ b/features/correct_feedback.feature
@@ -4,16 +4,25 @@ Feature: Correct feedback
   I want correct feedback in unusal cases
 
   Scenario: Gem not updated to its latest version
-    Given a Gemfile specifying:
+    Given the following remote gems:
+      | name | version |
+      | bar  | 1.0.0   |
+      | bar  | 1.1.0   |
+      | bar  | 1.2.0   |
+    And a Gemfile specifying:
       """
       gem 'bar', ['>= 1.0.0', '< 1.2.0']
       """
-    And a gem named "bar" at version "1.0.0"
+    And a Gemfile.lock specifying:
+      """
+      GEM
+        specs:
+          bar (1.0.0)
+
+      """
     And the initial bundle install committed
-    And a gem named "bar" at version "1.1.0"
-    And a gem named "bar" at version "1.2.0"
     When I run `keep_up`
-    Then the stdout should contain:
+    Then the output should contain:
       """
       Updating bar
       Updated bar to 1.1.0
@@ -31,13 +40,22 @@ Feature: Correct feedback
       """
 
   Scenario: Gem not updated at all
-    Given a Gemfile specifying:
+    Given the following remote gems:
+      | name | version |
+      | bar  | 1.0.0   |
+      | bar  | 1.2.0   |
+    And a Gemfile specifying:
       """
       gem 'bar', ['>= 1.0.0', '< 1.2.0']
       """
-    And a gem named "bar" at version "1.0.0"
+    And a Gemfile.lock specifying:
+      """
+      GEM
+        specs:
+          bar (1.0.0)
+
+      """
     And the initial bundle install committed
-    And a gem named "bar" at version "1.2.0"
     When I run `keep_up`
     Then the stdout should contain:
       """

--- a/features/failed_bundle_update.feature
+++ b/features/failed_bundle_update.feature
@@ -4,16 +4,26 @@ Feature: Skip failing updates
   I want failed updates to be skipped
 
   Scenario: Skipping due to version conflict
-    Given a Gemfile specifying:
+    Given the following remote gems:
+      | name | version | depending on | at version |
+      | bar  | 1.0.0   |              |            |
+      | foo  | 1.0.0   |              |            |
+      | bar  | 1.2.0   | foo          | 1.2.0      |
+      | foo  | 1.2.0   |              |            |
+    And a Gemfile specifying:
       """
       gem 'bar', '1.0.0'
       gem 'foo', '1.0.0'
       """
-    And a gem named "bar" at version "1.0.0"
-    And a gem named "foo" at version "1.0.0"
+    And a Gemfile.lock specifying:
+      """
+      GEM
+        specs:
+          foo (1.0.0)
+          bar (1.0.0)
+
+      """
     And the initial bundle install committed
-    And a gem named "bar" at version "1.2.0" depending on "foo" at version "1.2.0"
-    And a gem named "foo" at version "1.2.0"
     When I run `keep_up`
     Then the stdout should contain:
       """

--- a/features/gemspec_dependencies.feature
+++ b/features/gemspec_dependencies.feature
@@ -4,18 +4,23 @@ Feature: Gemspec dependencies
   I want to update dependencies in a gemspec
 
   Scenario: Updating a gemspec with fixed dependency versions
-    Given a Gemfile specifying:
+    Given the following remote gems:
+      | name | version |
+      | foo  | 1.0.0   |
+      | foo  | 1.0.1   |
+    And a Gemfile specifying:
       """
       gemspec
       """
     And a gemspec for "bar" depending on "foo" at version "1.0.0"
-    And a gem named "foo" at version "1.0.0"
+    And a Gemfile.lock specifying:
+      """
+      GEM
+        specs:
+          foo (1.0.0)
+
+      """
     And the initial bundle install committed
-    Then the file "Gemfile.lock" should contain:
-      """
-      foo (1.0.0)
-      """
-    Given a gem named "foo" at version "1.0.1"
     When I run `keep_up`
     Then the stdout should contain:
       """

--- a/features/indirect_dependencies.feature
+++ b/features/indirect_dependencies.feature
@@ -4,14 +4,25 @@ Feature: Updating indirect dependencies
   I want to also update dependencies I haven't specified myself
 
   Scenario: An indirect dependency has an update
-    Given a Gemfile specifying:
+    Given the following remote gems:
+      | name | version | depending on | at version |
+      | foo  | 1.0.0   | bar          | ~> 1.0.0   |
+      | bar  | 1.0.0   |              |            |
+      | bar  | 1.0.1   |              |            |
+    And a Gemfile specifying:
       """
       gem 'foo', '1.0.0'
       """
-    And a gem named "foo" at version "1.0.0" depending on "bar" at version "~> 1.0.0"
-    And a gem named "bar" at version "1.0.0"
+    And a Gemfile.lock specifying:
+      """
+      GEM
+        specs:
+          bar (1.0.0)
+          foo (1.0.0)
+            bar (~> 1.0.0)
+
+      """
     And the initial bundle install committed
-    And a gem named "bar" at version "1.0.1"
     When I run `keep_up`
     Then the stdout should contain exactly:
       """

--- a/features/matching_specificity.feature
+++ b/features/matching_specificity.feature
@@ -4,14 +4,23 @@ Feature: Matching specificity correctly
   I want to trust semantic versioning
 
   Scenario: Matching specificity while updating a gemspec
-    Given a Gemfile specifying:
+    Given the following remote gems:
+      | name | version |
+      | foo  | 1.0.0   |
+      | foo  | 2.1.1   |
+    And a Gemfile specifying:
       """
       gemspec
       """
     And a gemspec for "bar" depending on "foo" at version "~> 1.0"
-    And a gem named "foo" at version "1.0.0"
+    And a Gemfile.lock specifying:
+      """
+      GEM
+        specs:
+          foo (1.0.0)
+
+      """
     And the initial bundle install committed
-    And a gem named "foo" at version "2.1.1"
     When I run `keep_up`
     Then the stdout should contain:
       """
@@ -30,13 +39,22 @@ Feature: Matching specificity correctly
       """
 
   Scenario: Matching specificity while updating a Gemfile
-    Given a Gemfile specifying:
+    Given the following remote gems:
+      | name | version |
+      | foo  | 1.0.0   |
+      | foo  | 2.1.1   |
+    And a Gemfile specifying:
       """
       gem 'foo', '~> 1.0'
       """
-    And a gem named "foo" at version "1.0.0"
+    And a Gemfile.lock specifying:
+      """
+      GEM
+        specs:
+          foo (1.0.0)
+
+      """
     And the initial bundle install committed
-    And a gem named "foo" at version "2.1.1"
     When I run `keep_up`
     Then the stdout should contain:
       """

--- a/features/sanity_check.feature
+++ b/features/sanity_check.feature
@@ -4,13 +4,22 @@ Feature: Sanity check
   I want to have some checks done before keep_up starts
 
   Scenario: Check clean checkout directory
-    Given a Gemfile specifying:
+    Given the following remote gems:
+      | name | version |
+      | foo  | 1.0.0   |
+      | foo  | 1.0.1   |
+    And a Gemfile specifying:
       """
       gem 'foo', '1.0.0'
       """
-    And a gem named "foo" at version "1.0.0"
+    And a Gemfile.lock specifying:
+      """
+      GEM
+        specs:
+          foo (1.0.0)
+
+      """
     And the initial bundle install committed
-    And a gem named "foo" at version "1.0.1"
     When I add a file without checking it in
     And I run `keep_up`
     Then the stdout should not contain:
@@ -24,12 +33,21 @@ Feature: Sanity check
       """
 
   Scenario: Check bundle status
-    Given a Gemfile specifying:
+    Given the following remote gems:
+      | name | version |
+      | foo  | 1.0.0   |
+      | foo  | 1.0.1   |
+    And a Gemfile specifying:
       """
       gem 'foo', '1.0.1'
       """
-    And a gem named "foo" at version "1.0.0"
-    And a gem named "foo" at version "1.0.1"
+    And a Gemfile.lock specifying:
+      """
+      GEM
+        specs:
+          foo (1.0.1)
+
+      """
     And the initial bundle install committed
     When I update the Gemfile to specify:
       """

--- a/features/skipping_dependencies.feature
+++ b/features/skipping_dependencies.feature
@@ -4,16 +4,26 @@ Feature: Skipping dependencies
   I want to be able to skip specific gems while updating
 
   Scenario: Specifying gems to skip on the command line
-    Given a Gemfile specifying:
+    Given the following remote gems:
+      | name | version |
+      | foo  | 1.0.0   |
+      | foo  | 1.2.0   |
+      | bar  | 1.0.0   |
+      | bar  | 1.2.0   |
+    And a Gemfile specifying:
       """
       gem 'bar', '1.0.0'
       gem 'foo', '1.0.0'
       """
-    And a gem named "bar" at version "1.0.0"
-    And a gem named "foo" at version "1.0.0"
+    And a Gemfile.lock specifying:
+      """
+      GEM
+        specs:
+          foo (1.0.0)
+          bar (1.0.0)
+
+      """
     And the initial bundle install committed
-    And a gem named "bar" at version "1.2.0"
-    And a gem named "foo" at version "1.2.0"
     When I run `keep_up --skip bar`
     Then the stdout should contain:
       """

--- a/features/update_approximate_versions.feature
+++ b/features/update_approximate_versions.feature
@@ -8,11 +8,20 @@ Feature: Update bundle with approximate versions
       """
       gem 'foo', '~> 1.0.0'
       """
-    And a gem named "foo" at version "1.0.0"
-    And the initial bundle install committed
+    And a Gemfile.lock specifying:
+      """
+      GEM
+        specs:
+          foo (1.0.0)
+
+      """
 
   Scenario: Updating to a version that matches the current spec
-    Given a gem named "foo" at version "1.0.1"
+    Given the following remote gems:
+      | name | version |
+      | foo  | 1.0.0   |
+      | foo  | 1.0.1   |
+    And the initial bundle install committed
     When I run `keep_up`
     Then the stdout should contain:
       """
@@ -29,7 +38,11 @@ Feature: Update bundle with approximate versions
       """
 
   Scenario: Updating to a version that exceeds the current spec
-    Given a gem named "foo" at version "1.1.2"
+    Given the following remote gems:
+      | name | version |
+      | foo  | 1.0.0   |
+      | foo  | 1.1.2   |
+    And the initial bundle install committed
     When I run `keep_up`
     Then the stdout should contain:
       """

--- a/features/without_dependency_versions.feature
+++ b/features/without_dependency_versions.feature
@@ -4,13 +4,22 @@ Feature: Update bundle with no depenency versions
   I want to specify no versions
 
   Scenario: Updating an unversioned depedency
-    Given a Gemfile specifying:
+    Given the following remote gems:
+      | name | version |
+      | foo  | 1.0.0   |
+      | foo  | 1.0.1   |
+    And a Gemfile specifying:
       """
       gem 'foo'
       """
-    And a gem named "foo" at version "1.0.0"
+    And a Gemfile.lock specifying:
+      """
+      GEM
+        specs:
+          foo (1.0.0)
+
+      """
     And the initial bundle install committed
-    And a gem named "foo" at version "1.0.1"
     When I run `keep_up`
     Then the stdout should contain:
       """


### PR DESCRIPTION
This groups the specification of remote gems together into a single step, and generates the gem index only once. Since generating the index is quite slow, this saves quite some time per scenario.

The downside is that the contents of the lockfile need to be specified explicitly, rather than relying on bundle install to create it correctly for the given scenario. Given the resulting speed-up, I think this is worth it.
