### PR TITLE
Support Ruby 3.1 through 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/keep_up.gemspec
+++ b/keep_up.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bundler", "~> 2.0"
 
   spec.add_development_dependency "aruba", "~> 2.0"
-  spec.add_development_dependency "cucumber", "~> 9.0"
+  spec.add_development_dependency "cucumber", "~> 9.2", ">= 9.2.1"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/keep_up.gemspec
+++ b/keep_up.gemspec
@@ -13,8 +13,9 @@ Gem::Specification.new do |spec|
     "Automatically update the dependencies listed in your Gemfile," \
     " Gemfile.lock, and gemspec."
   spec.homepage = "https://github.com/mvz/keep_up"
+
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["rubygems_mfa_required"] = "true"


### PR DESCRIPTION
This drops support for Ruby 3.0 which is EOL.
